### PR TITLE
fix(desktop): Resolve server startup and port conflict errors

### DIFF
--- a/backend/grpc_server.py
+++ b/backend/grpc_server.py
@@ -75,9 +75,11 @@ def demarrer_serveur_grpc():
     serveur = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     transfer_pb2_grpc.add_FileTransferServicer_to_server(FileTransferServicer(), serveur)
     port = '50051'
-    serveur.add_insecure_port(f'[::]:{port}')
+    # Utilise 0.0.0.0 pour une meilleure compatibilité que [::]
+    adresse_ecoute = f'0.0.0.0:{port}'
+    serveur.add_insecure_port(adresse_ecoute)
     serveur.start()
-    print(f"Serveur gRPC démarré et à l'écoute sur le port {port}")
+    print(f"Serveur gRPC démarré et à l'écoute sur {adresse_ecoute}")
     serveur.wait_for_termination()
 
 if __name__ == '__main__':

--- a/backend/main.py
+++ b/backend/main.py
@@ -158,4 +158,4 @@ async def websocket_endpoint(websocket: WebSocket, id_appareil: str):
 
 # --- Lancement ---
 if __name__ == "__main__":
-    uvicorn.run("main:application_fastapi", host="127.0.0.1", port=8000, reload=True)
+    uvicorn.run("main:application_fastapi", host="127.0.0.1", port=8001, reload=True)

--- a/main.js
+++ b/main.js
@@ -42,8 +42,8 @@ function creer_fenetre() {
 
 // Fonctions pour démarrer les serveurs backend.
 function demarrer_serveur_fastapi() {
-  console.log('Démarrage du serveur FastAPI...');
-  processus_fastapi = spawn('python', ['-m', 'uvicorn', 'main:application_fastapi', '--host', '127.0.0.1', '--port', '8000'], {
+  console.log('Démarrage du serveur FastAPI sur le port 8001...');
+  processus_fastapi = spawn('python', ['-m', 'uvicorn', 'main:application_fastapi', '--host', '127.0.0.1', '--port', '8001'], {
     cwd: path.join(__dirname, 'backend'),
     shell: true,
   });

--- a/src/composants/Appareils.js
+++ b/src/composants/Appareils.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './Appareils.css';
-
-const API_URL = 'http://localhost:8000';
+import { API_URL } from '../config';
 
 function Appareils() {
   const [appareils, definirAppareils] = useState([]);

--- a/src/composants/EcranAppairage.js
+++ b/src/composants/EcranAppairage.js
@@ -2,10 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios'; // Pour faire des requêtes HTTP vers le backend
 import { QRCodeSVG } from 'qrcode.react'; // Pour générer le QR code
 import './EcranAppairage.css'; // Styles spécifiques à cet écran
-
-// L'URL de base de notre API backend.
-// En développement, le serveur Python tourne sur le port 8000.
-const API_URL = 'http://localhost:8000';
+import { API_URL } from '../config';
 
 function EcranAppairage({ surAppairageReussi }) {
   // Déclaration des états du composant avec le hook `useState`.

--- a/src/composants/ExplorateurFichiers.js
+++ b/src/composants/ExplorateurFichiers.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './ExplorateurFichiers.css';
-
-const API_URL = 'http://localhost:8000';
+import { API_URL } from '../config';
 
 // --- Helper Functions ---
 

--- a/src/composants/Parametres.js
+++ b/src/composants/Parametres.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './Parametres.css';
-
-const API_URL = 'http://localhost:8000';
+import { API_URL } from '../config';
 
 function Parametres() {
   const [parametres, definirParametres] = useState(null);

--- a/src/composants/TableauDeBord.js
+++ b/src/composants/TableauDeBord.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import './TableauDeBord.css';
-
-const API_URL = 'http://localhost:8000';
+import { API_URL } from '../config';
 
 // Composant pour afficher les statistiques de stockage
 function WidgetStockage({ stockage }) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,4 @@
+// Fichier de configuration central pour les constantes de l'application frontend.
+
+const API_PORT = 8001;
+export const API_URL = `http://localhost:${API_PORT}`;


### PR DESCRIPTION
This commit fixes two critical errors that prevented the desktop application from launching correctly.

1.  **Resolves gRPC server binding error:** Changes the gRPC server binding address from `[::]` to `0.0.0.0` for better compatibility, especially on Windows systems. This fixes the `Failed to bind to address [::]:50051` error.

2.  **Resolves FastAPI port conflict:**
    - Changes the default port for the FastAPI server from 8000 to 8001 to avoid common port conflicts with other development tools. This fixes the `[winerror 10048]` address already in use error.
    - Centralizes the API URL into a `src/config.js` file.
    - Updates all React components (`EcranAppairage`, `TableauDeBord`, etc.) to use the new centralized config.
    - Updates `main.js` to spawn the FastAPI process on the new port.